### PR TITLE
Add semweb context

### DIFF
--- a/docs/_data/contexts/semweb_context.jsonld
+++ b/docs/_data/contexts/semweb_context.jsonld
@@ -1,0 +1,17 @@
+{
+    "@context": {
+        "ac": "http://www.w3.org/ns/activitystreams#",
+        "dc.terms": "https://dublincore.org/specifications/dublin-core/dcmi-terms/#",
+        "dcat": "http://www.w3.org/ns/dcat#",
+        "faldo": "http://biohackathon.org/resource/faldo#",
+        "foaf": "http://xmlns.com/foaf/0.1/",
+        "idot": "http://identifiers.org/idot/",
+        "oa": "http://www.w3.org/ns/oa#",
+        "owl": "http://www.w3.org/2002/07/owl#",
+        "prov": "https://www.w3.org/ns/prov#",
+        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "void": "http://rdfs.org/ns/void#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#"
+    }
+}

--- a/docs/_data/contexts/semweb_context.jsonld
+++ b/docs/_data/contexts/semweb_context.jsonld
@@ -7,6 +7,7 @@
         "foaf": "http://xmlns.com/foaf/0.1/",
         "idot": "http://identifiers.org/idot/",
         "oa": "http://www.w3.org/ns/oa#",
+        "oboinowl": "http://www.geneontology.org/formats/oboInOwl#",
         "owl": "http://www.w3.org/2002/07/owl#",
         "prov": "https://www.w3.org/ns/prov#",
         "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",

--- a/docs/_data/contexts/semweb_context.jsonld
+++ b/docs/_data/contexts/semweb_context.jsonld
@@ -1,11 +1,12 @@
 {
     "@context": {
         "ac": "http://www.w3.org/ns/activitystreams#",
-        "dc.terms": "https://dublincore.org/specifications/dublin-core/dcmi-terms/#",
         "dcat": "http://www.w3.org/ns/dcat#",
+        "dcterms": "https://dublincore.org/specifications/dublin-core/dcmi-terms/#",
+        "dctypes": "http://purl.org/dc/dcmitype/",
         "faldo": "http://biohackathon.org/resource/faldo#",
         "foaf": "http://xmlns.com/foaf/0.1/",
-        "idot": "http://identifiers.org/idot/",
+        "idot": "https://biomodels.net/vocab/idot.rdf#",
         "oa": "http://www.w3.org/ns/oa#",
         "oboinowl": "http://www.geneontology.org/formats/oboInOwl#",
         "owl": "http://www.w3.org/2002/07/owl#",

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -74,6 +74,11 @@
       "prefix": "ABS"
     }
   },
+  "ac": {
+    "homepage": "http://www.w3.org/ns/activitystreams",
+    "name": "Activity Streams",
+    "url": "http://www.w3.org/ns/activitystreams#$1"
+  },
   "aceview.worm": {
     "mappings": {
       "prefixcommons": "ACEVIEW.WORM"
@@ -5985,6 +5990,12 @@
     },
     "url": "https://dublincore.org/specifications/dublin-core/dcmi-terms/#$1"
   },
+  "dc.types": {
+    "example": "Collection",
+    "homepage": "https://dublincore.org/specifications/dublin-core/dcmi-terms/",
+    "name": "Dublin Core Types",
+    "url": "http://purl.org/dc/dcmitype/$1"
+  },
   "dcat": {
     "biolink": {
       "formatter": "http://www.w3.org/ns/dcat#$1",
@@ -8686,6 +8697,12 @@
       "is_obo": false,
       "prefix": "FAIRSHARING"
     }
+  },
+  "faldo": {
+    "example": "ForwardStrandPosition",
+    "homepage": "http://biohackathon.org/resource/faldo",
+    "name": "Feature Annotation Location Description Ontology ",
+    "url": "http://biohackathon.org/resource/faldo#$1"
   },
   "fao": {
     "bioportal": {
@@ -12921,6 +12938,7 @@
     }
   },
   "idot": {
+    "homepage": "http://biomodels.net/vocab/idot.rdf",
     "mappings": {
       "prefixcommons": "IDOT"
     },
@@ -18835,6 +18853,11 @@
       "prefix": "NUCLEARBD"
     }
   },
+  "oa": {
+    "homepage": "http://www.w3.org/ns/oa",
+    "name": "Web Annotation Ontology",
+    "url": "http://www.w3.org/ns/oa#$1"
+  },
   "oae": {
     "bioportal": {
       "name": "Ontology of Adverse Events",
@@ -20555,7 +20578,8 @@
       "is_identifiers": false,
       "is_obo": false,
       "prefix": "owl"
-    }
+    },
+    "url": "http://www.w3.org/2002/07/owl#$1"
   },
   "p3db.protein": {
     "mappings": {
@@ -23489,6 +23513,18 @@
       "version.iri": "http://purl.obolibrary.org/obo/rbo/releases/2021-05-21/rbo.owl"
     },
     "ols_version_date_format": "%Y-%m-%d"
+  },
+  "rdf": {
+    "example": "RDF",
+    "homepage": "http://www.w3.org/1999/02/22-rdf-syntax-ns",
+    "name": "Resource Description Framework",
+    "url": "http://www.w3.org/1999/02/22-rdf-syntax-ns#$1"
+  },
+  "rdfs": {
+    "example": "label",
+    "homepage": "https://www.w3.org/TR/rdf-schema/",
+    "name": "RDF Schema",
+    "url": "http://www.w3.org/2000/01/rdf-schema#$1"
   },
   "rdo": {
     "_download": "http://ratmine.mcw.edu/ontology/disease/RDO.obo",
@@ -28537,6 +28573,12 @@
       "prefix": "VO"
     }
   },
+  "void": {
+    "example": "feature",
+    "homepage": "http://vocab.deri.ie/void",
+    "name": "Vocabulary of Interlinked Datasets",
+    "url": "http://rdfs.org/ns/void#$1"
+  },
   "vsao": {
     "bioportal": {
       "name": "Vertebrate Skeletal Anatomy Ontology",
@@ -28943,6 +28985,7 @@
       "is_obo": false,
       "prefix": "WIKIDATA_PROPERTY"
     },
+    "example": "P4355",
     "mappings": {
       "biolink": "WIKIDATA_PROPERTY",
       "prefixcommons": "WD_Prop"
@@ -29379,6 +29422,11 @@
     },
     "ols_version_date_format": "%Y-%m-%d",
     "pattern": "^\\d+$"
+  },
+  "xsd": {
+    "homepage": "http://www.w3.org/2001/XMLSchema",
+    "name": "XML Schema Definition",
+    "url": "http://www.w3.org/2001/XMLSchema#$1"
   },
   "xuo": {
     "appears_in": [

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -19110,6 +19110,13 @@
       "prefix": "OBO"
     }
   },
+  "oboinowl": {
+    "download": "https://github.com/geneontology/go-ontology/raw/master/contrib/oboInOwl.obo",
+    "example": "DbXref",
+    "homepage": "https://github.com/geneontology/go-ontology/tree/master/contrib",
+    "name": "OBO in OWL",
+    "url": "http://www.geneontology.org/formats/oboInOwl#$1"
+  },
   "occ": {
     "miriam": {
       "deprecated": false,

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -5964,38 +5964,6 @@
       "prefix": "dc"
     }
   },
-  "dc.terms": {
-    "biolink": {
-      "formatter": "http://purl.org/dc/terms/$1",
-      "is_identifiers": false,
-      "is_obo": false,
-      "prefix": "dct"
-    },
-    "bioportal": {
-      "name": "DCMI Metadata Terms: properties in /terms/ namespace",
-      "prefix": "DCTERMS"
-    },
-    "example": "title",
-    "mappings": {
-      "biolink": "dct",
-      "bioportal": "DCTERMS",
-      "prefixcommons": "dcterms"
-    },
-    "name": "Dublin Core Metadata Vocabulary",
-    "prefixcommons": {
-      "formatter": "http://purl.org/dc/terms/$1",
-      "is_identifiers": false,
-      "is_obo": false,
-      "prefix": "dcterms"
-    },
-    "url": "https://dublincore.org/specifications/dublin-core/dcmi-terms/#$1"
-  },
-  "dc.types": {
-    "example": "Collection",
-    "homepage": "https://dublincore.org/specifications/dublin-core/dcmi-terms/",
-    "name": "Dublin Core Types",
-    "url": "http://purl.org/dc/dcmitype/$1"
-  },
   "dcat": {
     "biolink": {
       "formatter": "http://www.w3.org/ns/dcat#$1",
@@ -6022,6 +5990,41 @@
       "prefix": "dcat"
     },
     "url": "http://www.w3.org/ns/dcat#$1"
+  },
+  "dcterms": {
+    "biolink": {
+      "formatter": "http://purl.org/dc/terms/$1",
+      "is_identifiers": false,
+      "is_obo": false,
+      "prefix": "dct"
+    },
+    "bioportal": {
+      "name": "DCMI Metadata Terms: properties in /terms/ namespace",
+      "prefix": "DCTERMS"
+    },
+    "example": "title",
+    "mappings": {
+      "biolink": "dct",
+      "bioportal": "DCTERMS",
+      "prefixcommons": "dcterms"
+    },
+    "name": "Dublin Core Metadata Vocabulary",
+    "prefixcommons": {
+      "formatter": "http://purl.org/dc/terms/$1",
+      "is_identifiers": false,
+      "is_obo": false,
+      "prefix": "dcterms"
+    },
+    "synonyms": [
+      "dc.terms"
+    ],
+    "url": "https://dublincore.org/specifications/dublin-core/dcmi-terms/#$1"
+  },
+  "dctypes": {
+    "example": "Collection",
+    "homepage": "https://dublincore.org/specifications/dublin-core/dcmi-terms/",
+    "name": "Dublin Core Types",
+    "url": "http://purl.org/dc/dcmitype/$1"
   },
   "ddanat": {
     "bioportal": {
@@ -12960,7 +12963,8 @@
       "is_identifiers": true,
       "is_obo": false,
       "prefix": "IDOT"
-    }
+    },
+    "url": "https://biomodels.net/vocab/idot.rdf#$1"
   },
   "idr": {
     "mapping": {

--- a/src/bioregistry/data/collections.json
+++ b/src/bioregistry/data/collections.json
@@ -26,5 +26,29 @@
       "emdb",
       "bmrb"
     ]
+  },
+  "0000002": {
+    "name": "Semantic Web Context",
+    "contextName": "semweb",
+    "description": "Resources used in the semantic web, based on https://github.com/prefixcommons/biocontext/blob/master/registry/semweb_context.yaml.",
+    "author": {
+      "name": "Charles Tapley Hoyt",
+      "orcid": "0000-0003-4423-4370"
+    },
+    "resources": [
+      "ac",
+      "rdf",
+      "rdfs",
+      "owl",
+      "xsd",
+      "dc.terms",
+      "faldo",
+      "foaf",
+      "oa",
+      "idot",
+      "void",
+      "prov",
+      "dcat"
+    ]
   }
 }

--- a/src/bioregistry/data/collections.json
+++ b/src/bioregistry/data/collections.json
@@ -47,6 +47,7 @@
       "foaf",
       "idot",
       "oa",
+      "oboinowl",
       "owl",
       "prov",
       "rdf",

--- a/src/bioregistry/data/collections.json
+++ b/src/bioregistry/data/collections.json
@@ -41,8 +41,9 @@
     "name": "Semantic Web Context",
     "resources": [
       "ac",
-      "dc.terms",
       "dcat",
+      "dcterms",
+      "dctypes",
       "faldo",
       "foaf",
       "idot",

--- a/src/bioregistry/data/collections.json
+++ b/src/bioregistry/data/collections.json
@@ -30,10 +30,12 @@
     ]
   },
   "0000002": {
-    "author": {
-      "name": "Charles Tapley Hoyt",
-      "orcid": "0000-0003-4423-4370"
-    },
+    "authors": [
+      {
+        "name": "Charles Tapley Hoyt",
+        "orcid": "0000-0003-4423-4370"
+      }
+    ],
     "contextName": "semweb",
     "description": "Resources used in the semantic web, based on https://github.com/prefixcommons/biocontext/blob/master/registry/semweb_context.yaml.",
     "name": "Semantic Web Context",

--- a/src/bioregistry/data/collections.json
+++ b/src/bioregistry/data/collections.json
@@ -30,27 +30,27 @@
     ]
   },
   "0000002": {
-    "name": "Semantic Web Context",
-    "contextName": "semweb",
-    "description": "Resources used in the semantic web, based on https://github.com/prefixcommons/biocontext/blob/master/registry/semweb_context.yaml.",
     "author": {
       "name": "Charles Tapley Hoyt",
       "orcid": "0000-0003-4423-4370"
     },
+    "contextName": "semweb",
+    "description": "Resources used in the semantic web, based on https://github.com/prefixcommons/biocontext/blob/master/registry/semweb_context.yaml.",
+    "name": "Semantic Web Context",
     "resources": [
       "ac",
-      "rdf",
-      "rdfs",
-      "owl",
-      "xsd",
       "dc.terms",
+      "dcat",
       "faldo",
       "foaf",
-      "oa",
       "idot",
-      "void",
+      "oa",
+      "owl",
       "prov",
-      "dcat"
+      "rdf",
+      "rdfs",
+      "void",
+      "xsd"
     ]
   }
 }

--- a/src/bioregistry/prefix_maps.py
+++ b/src/bioregistry/prefix_maps.py
@@ -3,6 +3,7 @@
 """Export the Bioregistry as a JSON-LD context."""
 
 import json
+import logging
 from pathlib import Path
 from typing import Mapping
 
@@ -10,6 +11,8 @@ import click
 
 import bioregistry
 from bioregistry.constants import DOCS_DATA
+
+logger = logging.getLogger(__name__)
 
 
 @click.command()
@@ -22,6 +25,33 @@ def generate_context_json_ld():
         json.dump(fp=file, indent=4, sort_keys=True, obj={
             "@context": get_obofoundry_prefix_map(),
         })
+
+    for key, collection in bioregistry.read_collections().items():
+        name = collection.get('contextName')
+        if name is None:
+            continue
+        with contexts_directory.joinpath(f'{name}_context').with_suffix('.jsonld').open('w') as file:
+            json.dump(fp=file, indent=4, sort_keys=True, obj={
+                "@context": get_collection_prefix_map(key),
+            })
+
+
+def get_collection_prefix_map(key: str) -> Mapping[str, str]:
+    """Get a prefix map for a given collection."""
+    rv = {}
+    for prefix in bioregistry.read_collections()[key]['resources']:
+        fmt = bioregistry.get_format(prefix)
+        if fmt is None:
+            logging.warning('collection term missing formatter: %s', prefix)
+            continue
+        if not fmt.endswith('$1'):
+            logging.warning('formatter missing $1: %s', prefix)
+            continue
+        if fmt.count('$1') != 1:
+            logging.warning('formatter has multiple $1: %s', prefix)
+            continue
+        rv[prefix] = fmt[:-len('$1')]
+    return rv
 
 
 def get_obofoundry_prefix_map() -> Mapping[str, str]:


### PR DESCRIPTION
Closes #52
CC @cmungall note there are a few discrepancies with https://github.com/prefixcommons/biocontext/blob/master/registry/semweb_context.jsonld. 

- `idot` entry is fixed
- `dc` is not given as a duplicate for `dc.terms`
- Some of the other URLs changed as well because they're automatically retrieved from the bioregistry