### PR TITLE
Update documentation pages

### DIFF
--- a/src/bioregistry/app/templates/access.html
+++ b/src/bioregistry/app/templates/access.html
@@ -1,0 +1,117 @@
+{% extends "prose.html" %}
+
+{% block title %}Bioregistry Programmatic Access{% endblock %}
+
+{% block styles %}
+    {{ super() }}
+    <link href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism.css" rel="stylesheet"/>
+{% endblock %}
+
+{% block scripts %}
+    {{ super() }}
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+{% endblock %}
+
+{% block content %}
+    <h2>API Usage</h2>
+    <p>
+        The Bioregistry web application is built on <a href="https://flask.palletsprojects.com">Flask</a>
+        as a thin wrapper around the <a href="https://github.com/bioregistry/bioregistry"><code>bioregistry</code></a>
+        Python package. It exposes several endpoints for accessing the registry, metaregistry, collections, and search
+        functionality for which <a href="https://swagger.io/">Swagger</a> API documentation is automatically generated
+        by <a href="https://github.com/flasgger/flasgger">Flasgger</a>.
+    </p>
+    <p>
+        See the remaining Bioregistry <a href="{{ url_for('flasgger.apidocs') }}"><i class="fas fa-book"></i> API
+        documentation</a> or follow some of these examples using Python:
+    </p>
+    <h3>Registry</h3>
+    <p>
+        Get the whole registry:
+    </p>
+    <pre><code class="language-python">import requests
+res = requests.get('https://bioregistry.io/api/registry').json()</code></pre>
+    <p>
+        Just get metadata for ChEBI:
+    </p>
+    <pre><code class="language-python">import requests
+res = requests.get('https://bioregistry.io/api/registry/chebi').json()</code></pre>
+    <p>
+        Get metadata about ChEBI entry 138488 (alsterpaullone):
+    </p>
+    <pre><code
+            class="language-python">res = requests.get('https://bioregistry.io/api/registry/chebi:138488').json()</code></pre>
+    <p>
+        Search prefixes containing <code>che</code>:
+    </p>
+    <pre><code class="language-python">res = requests.get(
+    'https://bioregistry.io/api/search',
+    params={'q': 'che'},
+).json()</code></pre>
+    <h3>Metaregistry</h3>
+    <p>TBD</p>
+    <h3>Collections</h3>
+    <p>TBD</p>
+    <h2>Python Package Usage</h2>
+    <p>
+        The Python source code can be found at
+        <a href="https://github.com/bioregistry/bioregistry"><i class="fab fa-github"></i> bioregistry/bioregistry</a>.
+        It can be installed with <code>pip install bioregistry</code> or in development mode by following
+        <a href="https://github.com/bioregistry/bioregistry#-installation">these instructions</a>.
+    </p>
+    <p>
+        The Bioregistry can be used to normalize prefixes across MIRIAM and all the (very plentiful) variants that pop
+        up in ontologies in OBO Foundry and the OLS with the <code>normalize_prefix()</code> function.
+    </p>
+    <pre><code class="language-python">import bioregistry
+
+# This works for synonym prefixes, like:
+assert 'ncbitaxon' == bioregistry.normalize_prefix('taxonomy')
+
+# This works for common mistaken prefixes, like:
+assert 'pubchem.compound' == bioregistry.normalize_prefix('pubchem')
+
+# This works for prefixes that are often written many ways, like:
+assert 'eccode' == bioregistry.normalize_prefix('ec-code')
+assert 'eccode' == bioregistry.normalize_prefix('EC_CODE')
+
+# If a prefix is not registered, it gives back `None`
+assert bioregistry.normalize_prefix('not a real key') is None</code></pre>
+    <p>
+        Entries in the Bioregistry can be looked up with the <code>get()</code> function.
+    </p>
+    <pre><code class="language-python">entry = bioregistry.get('taxonomy')
+# there are lots of mysteries to discover in this dictionary!</code></pre>
+    <p>
+        The full Bioregistry can be read in a Python project using:
+    </p>
+    <pre><code class="language-python">registry = bioregistry.read_registry()</code></pre>
+
+    <h2>Local Deployment of the Bioregistry Web Application</h2>
+    <p>
+        As the Bioregistry is open source, it's possible to host your own instance of the Bioregistry web application.
+        Further, it's possible create a local derivative of the registry, metaregistry, or collections that can be
+        deployed in your own instance. Here are examples how to do that:
+    </p>
+    <h4>Python CLI</h4>
+    <p>
+        You can also install and run the Bioregistry app from the shell:
+    </p>
+    <pre><code class="language-shell">$ pip install bioregistry[web]
+$ bioregistry web</code></pre>
+    <p>You can also download the source code, install in development mode, and run the Bioregistry app from the shell:
+    </p>
+    <pre><code class="language-shell">$ git clone https://github.com/bioregistry/bioregistry.git
+$ cd bioregistry
+$ pip install --editable .[web]
+$ bioregistry web</code></pre>
+    <h4>Docker</h4>
+    <p>You can deploy your own instance of the Bioregistry with:</p>
+    <pre><code class="language-shell">$ docker run -id -p 8766:8766 bioregistry/bioregistry:latest</code></pre>
+    <p>
+        If you want to mix using a custom version of the Bioregistry with a Docker-based deployment, please
+        see the dockerfile in <a href="https://github.com/bioregistry/bioregistry-docker">
+        <i class="fab fa-github"></i> bioregistry/bioregistry-docker</a> for inspiration.
+    </p>
+{% endblock %}

--- a/src/bioregistry/app/templates/access.html
+++ b/src/bioregistry/app/templates/access.html
@@ -1,6 +1,6 @@
 {% extends "prose.html" %}
 
-{% block title %}Bioregistry Programmatic Access{% endblock %}
+{% block title %}Bioregistry Programmatic Usage{% endblock %}
 
 {% block styles %}
     {{ super() }}
@@ -49,10 +49,12 @@ res = requests.get('https://bioregistry.io/api/registry/chebi').json()</code></p
     'https://bioregistry.io/api/search',
     params={'q': 'che'},
 ).json()</code></pre>
+    {#
     <h3>Metaregistry</h3>
-    <p>TBD</p>
+    <p>TODO</p>
     <h3>Collections</h3>
-    <p>TBD</p>
+    <p>TODO</p>
+    #}
     <h2>Python Package Usage</h2>
     <p>
         The Python source code can be found at

--- a/src/bioregistry/app/templates/base.html
+++ b/src/bioregistry/app/templates/base.html
@@ -52,11 +52,19 @@
             <li class="nav-item active">
                 <a class="nav-link" href="{{ url_for("ui.collections") }}">Collections</a>
             </li>
-            <li class="nav-item active">
-                <a class="nav-link" href="{{ url_for("summary") }}">Summary</a>
-            </li>
-            <li class="nav-item active">
-                <a class="nav-link" href="{{ url_for("download") }}">Downloads</a>
+
+
+            <li class="nav-item active dropdown">
+                <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    About
+                </a>
+                <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+                    <a class="dropdown-item" href="{{ url_for("summary") }}">Summary</a>
+                    <a class="dropdown-item" href="{{ url_for("download") }}">Downloads</a>
+                    <a class="dropdown-item" href="{{ url_for("access") }}">Programmatic Access</a>
+                    <a class="dropdown-item" href="{{ url_for("sustainability") }}">Sustainability</a>
+                    <!--<div class="dropdown-divider"></div>-->
+                </div>
             </li>
             <li class="nav-item active">
                 <a class="nav-link" href="{{ url_for('flasgger.apidocs') }}">API</a>

--- a/src/bioregistry/app/templates/base.html
+++ b/src/bioregistry/app/templates/base.html
@@ -60,11 +60,13 @@
                 </a>
                 <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                     <a class="dropdown-item" href="{{ url_for("summary") }}">Summary</a>
-                    <a class="dropdown-item" href="{{ url_for("download") }}">Downloads</a>
-                    <a class="dropdown-item" href="{{ url_for("access") }}">Programmatic Access</a>
-                    <a class="dropdown-item" href="{{ url_for("sustainability") }}">Sustainability</a>
+                    <a class="dropdown-item" href="{{ url_for("usage") }}">Programmatic Usage</a>
+                    <a class="dropdown-item" href="{{ url_for("sustainability") }}">Deployment and Sustainability</a>
                     <!--<div class="dropdown-divider"></div>-->
                 </div>
+            </li>
+            <li class="nav-item active">
+                <a class="nav-link" href="{{ url_for('download') }}">Downloads</a>
             </li>
             <li class="nav-item active">
                 <a class="nav-link" href="{{ url_for('flasgger.apidocs') }}">API</a>

--- a/src/bioregistry/app/templates/collections.html
+++ b/src/bioregistry/app/templates/collections.html
@@ -16,6 +16,14 @@
             </div>
         </div>
         <div class="card-body">
+            <p>
+                Collections are curated lists of prefixes along with a description of what the list is for. For example,
+                there's a <a href="{{ url_for("api.collection", identifier="0000001") }}">collection</a> that lists all
+                of the resources from the review article <i><a href="https://doi.org/10.1002/1873-3468.14067">Sharing
+                biological data: why, when, and how</a></i>. There's also a
+                <a href="{{ url_for("api.collection", identifier="0000002") }}">collection</a> comprising semantic web
+                prefixes.
+            </p>
             <p>New collections can be added in one of the following ways:</p>
             <ul>
                 <li>Edit the <a

--- a/src/bioregistry/app/templates/collections.html
+++ b/src/bioregistry/app/templates/collections.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% import "macros.html" as utils %}
 
-{% block title %}Bioregistry - Colletions{% endblock %}
+{% block title %}Bioregistry - Collections{% endblock %}
 
 {% block container %}
     <div class="card">

--- a/src/bioregistry/app/templates/download.html
+++ b/src/bioregistry/app/templates/download.html
@@ -14,9 +14,10 @@
 {% endblock %}
 
 {% block content %}
-    <h2>Download</h2>
+    <h2>Downloads</h2>
+    <h3>Registry</h3>
     <p>
-        The bioregistry database can be downloaded as:
+        The registry can be downloaded as:
     </p>
     <ul>
         <li>
@@ -31,7 +32,47 @@
     <p>
         The manually curated portions of these data are available under the
         <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">
+            <i class="fab fa-creative-commons-zero"></i> CC0 1.0 Universal License</a>. Aggregated data are
+        redistributed under their original licenses.
+    </p>
+    <h3>Metaregistry</h3>
+    <p>
+        The metaregistry can be downloaded as:
+    </p>
+    <ul>
+        <li>
+            <a href="https://github.com/bioregistry/bioregistry/blob/main/src/bioregistry/data/metaregistry.json">JSON</a>
+            (reference file)
+        </li>
+    </ul>
+    <p>
+        The entirety of the metaregistry is manually curated and is available under the
+        <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">
             <i class="fab fa-creative-commons-zero"></i> CC0 1.0 Universal License</a>.
+    </p>
+    <h3>Collections</h3>
+    <p>
+        The collections can be downloaded as:
+    </p>
+    <ul>
+        <li>
+            <a href="https://github.com/bioregistry/bioregistry/blob/main/src/bioregistry/data/collections.json">JSON</a>
+            (reference file)
+        </li>
+    </ul>
+    <p>
+        The entirety of the collections is manually curated and is available under the
+        <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">
+            <i class="fab fa-creative-commons-zero"></i> CC0 1.0 Universal License</a>.
+    </p>
+    <h2>Derived and Related Resources</h2>
+    <h3>Bioregistry Regular Expression Report</h3>
+    <p>
+        The Bioregistry Regular Expression Report uses <a href="https://github.com/pyobo/pyobo">PyOBO</a> to check how
+        consistent all of the regular expression patterns are with the actual identifiers from databases that are parsed
+        by PyOBO. This contains most entries from the OBO Foundry that are still accessible as well as several
+        additional resources such as HGNC, UniProt, etc. The automatically generated/updated report is available
+        <a href="https://bioregistry.github.io/regex-report/">here</a>.
     </p>
     <h3>Bioregistry Knowledge Graph</h3>
     <p>
@@ -40,53 +81,4 @@
         <a href="{{ url_for("ui.resolve", prefix="ndex", identifier="aa78a43f-9c4d-11eb-9e72-0ac135e8bacf") }}">
             Network Data Exchange (NDEx)</a>.
     </p>
-    <h2>API Usage</h2>
-    <p>
-        See the Swagger <a href="{{ url_for('flasgger.apidocs') }}">API documentation</a>.
-    </p>
-    <h2>Programmatic Usage</h2>
-    <p>
-        The Python source code can be found at
-        <a href="https://github.com/bioregistry/bioregistry"><i class="fab fa-github"></i> bioregistry/bioregistry</a>.
-        It can be installed with <code>pip install bioregistry</code> or in development mode by following
-        <a href="https://github.com/bioregistry/bioregistry#-installation">these instructions</a>.
-    </p>
-    <h3>Example Usage</h3>
-    <p>
-        The Bioregistry can be used to normalize prefixes across MIRIAM and all the (very plentiful) variants that pop
-        up in ontologies in OBO Foundry and the OLS with the <code>normalize_prefix()</code> function.
-    </p>
-    <pre><code class="language-python">
-    import bioregistry
-
-    # This works for synonym prefixes, like:
-    assert 'ncbitaxon' == bioregistry.normalize_prefix('taxonomy')
-
-    # This works for common mistaken prefixes, like:
-    assert 'chembl.compound' == bioregistry.normalize_prefix('chembl')
-
-    # This works for prefixes that are often written many ways, like:
-    assert 'eccode' == bioregistry.normalize_prefix('ec-code')
-    assert 'eccode' == bioregistry.normalize_prefix('EC_CODE')
-
-    # If a prefix is not registered, it gives back `None`
-    assert bioregistry.normalize_prefix('not a real key') is None
-    </code></pre>
-
-    Entries in the Bioregistry can be looked up with the <code>get()</code> function.
-
-    <pre><code class="language-python">
-    import bioregistry
-
-    entry = bioregistry.get('taxonomy')
-    # there are lots of mysteries to discover in this dictionary!
-    </code></pre>
-
-    The full Bioregistry can be read in a Python project using:
-
-    <pre><code class="language-python">
-    import bioregistry
-
-    registry = bioregistry.read_bioregistry()
-    </code></pre>
 {% endblock %}

--- a/src/bioregistry/app/templates/metaresources.html
+++ b/src/bioregistry/app/templates/metaresources.html
@@ -14,6 +14,12 @@
                 </div>
             </div>
         </div>
+        <div class="card-body">
+            <p>
+                The metaregistry contains metadata about registries including their names, descriptions, and their
+                various capabilities such as their ability to act as a resolver.
+            </p>
+        </div>
         <table id="table-entries" class="table table-striped table-hover ">
             <thead>
             <tr>

--- a/src/bioregistry/app/templates/resources.html
+++ b/src/bioregistry/app/templates/resources.html
@@ -19,7 +19,7 @@
     <script>
         $(document).ready(function () {
             $("#table-entries").DataTable({
-                "order": [[ 1, "asc" ]]
+                "order": [[1, "asc"]]
             });
             $("#table-entries_wrapper").children(":first-child").addClass("card-body");
             $("#table-entries_wrapper").children(":last-child").addClass("card-body");
@@ -38,6 +38,12 @@
                     </a>
                 </div>
             </div>
+        </div>
+        <div class="card-body" style="padding-bottom: 0">
+            <p style="margin-bottom: 0">
+                The registry contains metadata about ontologies, controlled vocabularies, and resources including their
+                preferred prefix, name, description, homepage, mappings to other registries, and more.
+            </p>
         </div>
         <table id="table-entries" class="table table-striped table-hover ">
             <thead>

--- a/src/bioregistry/app/templates/resources.html
+++ b/src/bioregistry/app/templates/resources.html
@@ -39,7 +39,7 @@
                 </div>
             </div>
         </div>
-        <div class="card-body" style="padding-bottom: 0">
+        <div class="card-body">
             <p style="margin-bottom: 0">
                 The registry contains metadata about ontologies, controlled vocabularies, and resources including their
                 preferred prefix, name, description, homepage, mappings to other registries, and more.

--- a/src/bioregistry/app/templates/summary.html
+++ b/src/bioregistry/app/templates/summary.html
@@ -66,7 +66,7 @@
     <p>
         The goal of the <a href="https://cthoyt.com/2020/04/19/inspector-javerts-xref-database.html">Inspector
         Javert's Xref Database</a> was to extract all the xrefs from OBO ontologies in the OBO Foundry. However,
-        most ontologies took a lot of creative freedom in how what prefixes they used to refer to which
+        most ontologies took a lot of creative freedom in what prefixes they used to refer to which
         resources, and they therefore had to be normalized. Unfortunately, most did not appear in popular
         registries like MIRIAM, so the Bioregistry was created to store this information and facilitate
         downstream data integration. Later, the Bioregistry became a tool that enabled the investigation of the
@@ -96,7 +96,7 @@
         Biological databases, ontologies, and resource will continue to be generated as we learn about new and
         exciting phenomena, so the medium-term plan to grow the Bioregistry is to continue to cover resources
         that are not covered by the other resources it references. New external registries can be suggested on
-        the Bioregistries GitHub <a href="https://github.com/bioregistry/bioregistry/issues/new">issue
+        the Bioregistry GitHub <a href="https://github.com/bioregistry/bioregistry/issues/new">issue
         tracker</a> using the <a href="https://github.com/bioregistry/bioregistry/labels/External%20Registry">External
         Registry</a> label. Further, there are <a
             href="https://github.com/bioregistry/bioregistry#-contributing">contribution guidelines</a> on the
@@ -215,7 +215,7 @@
     <p>
         While entries in the Bioregistry are <i>supposed</i> to represent nomenclature authorities, this is not always
         true because it imports from external sources that don't enforce this constraint.
-        For example, the Chemotoxicogenomics Database uses
+        For example, the Comparative Toxicogenomics Database uses
         <a href="{{ url_for('ui.resource', prefix='ncbigene') }}">NCBI Gene</a> for naming genes and
         <a href="{{ url_for('ui.resource', prefix='mesh') }}">MeSH</a> for naming diseases and chemicals.
         Identifiers.org has minted 3 prefixes

--- a/src/bioregistry/app/templates/sustainability.html
+++ b/src/bioregistry/app/templates/sustainability.html
@@ -1,0 +1,98 @@
+{% extends "prose.html" %}
+
+{% block title %}Bioregistry Sustainability{% endblock %}
+
+{% block styles %}
+    {{ super() }}
+    <link href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism.css" rel="stylesheet"/>
+{% endblock %}
+
+{% block scripts %}
+    {{ super() }}
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+{% endblock %}
+
+{% block content %}
+    <h1>Sustainability</h1>
+    <h2>Deployment in the Cloud</h2>
+    <p>
+        There are several aspects to the way the Bioregistry web application is deployed listed in this section.
+    </p>
+    <h3>Domain Name</h3>
+    <p>
+        The <code>bioregistry.io</code> domain is registered with Namecheap. It is managed and supported by the <a
+            href="https://indralab.github.io/">INDRA Lab</a>, a part of the <a
+            href="https://hits.harvard.edu/the-program/laboratory-of-systems-pharmacology/">Laboratory of
+        Systems Pharmacology</a> and <a href="https://hits.harvard.edu/">Harvard Program in Therapeutic Science
+        (HiTS)</a> at Harvard Medical School.
+    </p>
+    <h3>Hardware</h3>
+    <p>
+        The Bioregistry is hosted on an Amazon Elastic Compute Cloud (EC2) via a load balancing service to stay secure
+        and highly available. It is managed and supported by the <a href="https://indralab.github.io/">INDRA Lab</a>, a
+        part of the <a href="https://hits.harvard.edu/the-program/laboratory-of-systems-pharmacology/">Laboratory of
+        Systems Pharmacology</a> and <a href="https://hits.harvard.edu/">Harvard Program in Therapeutic Science
+        (HiTS)</a> at Harvard Medical School.
+    </p>
+    <h3>Deployment</h3>
+    <p>
+        A docker image is automatically built on a cron job in the
+        <a href="https://github.com/bioregistry/bioregistry-docker"><i class="fab fa-github"></i>
+            bioregistry/bioregistry-docker</a> GitHub repository
+        and pushed to the <a href="https://hub.docker.com/r/bioregistry/bioregistry"><i class="fab fa-docker"></i>
+        bioregistry/bioregistry</a> DockerHub repository.
+    </p>
+    <p>
+        The Bioregistry's EC2 instance runs the following script on a cron job that stops the current running instance,
+        pulls the latest image from this DockerHub repository and starts it back up. The whole process only takes a few
+        seconds.
+    </p>
+    <pre><code class="language-bash">#!/bin/bash
+
+# store the bioregistry id
+BIOREGISTRY_CONTAINER_ID=$(docker ps --filter "name=bioregistry" -q)
+
+# Stop and remove the old container taking advantage
+#   of the fact that it's named specifically
+docker stop $BIOREGISTRY_CONTAINER_ID
+docker rm $BIOREGISTRY_CONTAINER_ID
+
+# Pull the latest
+docker pull bioregistry/bioregistry:latest
+
+# Run the start script
+docker run -id --name bioregistry -p 8766:8766 bioregistry/bioregistry:latest</code></pre>
+    <h3>SSL/TLS</h3>
+    <p>
+        The SSL/TLS certificate for <code>bioregistry.io</code> so it can be served with HTTPS is managed through
+        the <a href="https://aws.amazon.com/certificate-manager/">AWS Certificate Manager</a>.
+    </p>
+    <h2>Data Maintenance, Interoperability with other Projects, and Project Governance</h2>
+    <p>
+        So far, the Bioregistry (both the data and web application) have been curated and developed within a small team
+        and used by a limited audience. This means we have been able to address issues very quickly. However, this
+        attitude is not scalable to larger audiences, where changes have higher potential for disruption of users'
+        usages. With that being said, there are many things we are looking to discuss with potential stakeholders
+        including (but not limited to):
+    </p>
+    <ul>
+        <li>Will the service still be running in 10 years?</li>
+        <li>Who makes technical decisions about how the web application?</li>
+        <li>Who makes curation decisions about the underlying registry?</li>
+        <li>
+            Should there be acceptance criteria for new entries, such as a minimum metadata standard or assessment of
+            impact?
+        </li>
+        <li>How should inevitable prefix/namespace collisions be handled?</li>
+        <li>... and many more</li>
+    </ul>
+    <p>
+        These questions do not have easy answers and apply to most databases, software, and web applications in the life
+        sciences. If you would like to be part of this discussion, please <a
+            href="https://join.slack.com/t/obo-communitygroup/shared_invite/zt-qdvt040i-ac3eU1MOgXF~lehfeNa9eA">join
+        us</a> on the OBO Community Slack workspace's <a
+            href="https://obo-communitygroup.slack.com/archives/C01E0H083BP">#ontotools</a>
+        channel.
+    </p>
+{% endblock %}

--- a/src/bioregistry/app/templates/sustainability.html
+++ b/src/bioregistry/app/templates/sustainability.html
@@ -35,6 +35,25 @@
         Systems Pharmacology</a> and <a href="https://hits.harvard.edu/">Harvard Program in Therapeutic Science
         (HiTS)</a> at Harvard Medical School.
     </p>
+    <h3>Software</h3>
+    <dl>
+        <dt>Bioregistry Version</dt>
+        <dd>{{ software_version }}</dd>
+        {% if software_git_hash %}
+            <dt>Git Hash</dt>
+            <dd>
+                <a href="https://github.com/bioregistry/bioregistry/commit/{{ software_git_hash }}">
+                    {{ software_git_hash }}
+                </a>
+            </dd>
+        {% endif %}
+        <dt>Python</dt>
+        <dd>{{ python_version }}</dd>
+        <dt>Platform</dt>
+        <dd>{{ platform }}</dd>
+        <dt>Platform Version</dt>
+        <dd>{{ platform_version }}</dd>
+    </dl>
     <h3>Deployment</h3>
     <p>
         A docker image is automatically built on a cron job in the

--- a/src/bioregistry/app/templates/sustainability.html
+++ b/src/bioregistry/app/templates/sustainability.html
@@ -1,6 +1,6 @@
 {% extends "prose.html" %}
 
-{% block title %}Bioregistry Sustainability{% endblock %}
+{% block title %}Bioregistry Deployment and Sustainability{% endblock %}
 
 {% block styles %}
     {{ super() }}

--- a/src/bioregistry/app/wsgi.py
+++ b/src/bioregistry/app/wsgi.py
@@ -170,5 +170,17 @@ def download():
     return render_template('download.html')
 
 
+@app.route('/sustainability')
+def sustainability():
+    """Render the sustainability page."""
+    return render_template('sustainability.html')
+
+
+@app.route('/access')
+def access():
+    """Render the programmatic access page."""
+    return render_template('access.html')
+
+
 if __name__ == '__main__':
     app.run(debug=True)  # noqa

--- a/src/bioregistry/app/wsgi.py
+++ b/src/bioregistry/app/wsgi.py
@@ -176,9 +176,9 @@ def sustainability():
     return render_template('sustainability.html')
 
 
-@app.route('/access')
-def access():
-    """Render the programmatic access page."""
+@app.route('/usage')
+def usage():
+    """Render the programmatic usage page."""
     return render_template('access.html')
 
 

--- a/src/bioregistry/app/wsgi.py
+++ b/src/bioregistry/app/wsgi.py
@@ -180,7 +180,6 @@ _PLATFORM_VERSION = platform.version()
 _PYTHON_VERSION = platform.python_version()
 
 
-
 @app.route('/sustainability')
 def sustainability():
     """Render the sustainability page."""

--- a/src/bioregistry/app/wsgi.py
+++ b/src/bioregistry/app/wsgi.py
@@ -2,11 +2,14 @@
 
 """Web application for the Bioregistry."""
 
+import platform
+
 from flasgger import Swagger
 from flask import Blueprint, Flask, abort, jsonify, render_template, request
 from flask_bootstrap import Bootstrap
 
 import bioregistry
+from bioregistry import version
 from bioregistry.app.ui import ui_blueprint
 from .utils import _autocomplete, _get_identifier, _normalize_prefix_or_404, _search
 from ..resolve_identifier import _get_bioregistry_link
@@ -170,10 +173,25 @@ def download():
     return render_template('download.html')
 
 
+_VERSION = version.get_version()
+_GIT_HASH = version.get_git_hash()
+_PLATFORM = platform.platform()
+_PLATFORM_VERSION = platform.version()
+_PYTHON_VERSION = platform.python_version()
+
+
+
 @app.route('/sustainability')
 def sustainability():
     """Render the sustainability page."""
-    return render_template('sustainability.html')
+    return render_template(
+        'sustainability.html',
+        software_version=_VERSION,
+        software_git_hash=_GIT_HASH,
+        platform=_PLATFORM,
+        platform_version=_PLATFORM_VERSION,
+        python_version=_PYTHON_VERSION,
+    )
 
 
 @app.route('/usage')


### PR DESCRIPTION
This PR reorganizes the previous "documentation" pages for the summary and download into several pages. It also adds a new page on "sustainability" which includes a much more detailed description of how the app is managed as well as allusions to some of the discussions we've been having on the OBO Community slack.

@bgyori it would be nice if you could take a look at the text. Probably easiest to deploy the app yourself and read from the browser with:

```shell
$ git clone git@github.com:bioregistry/bioregistry.git
$ git checkout update-meta
$ pip install -e .
$ bioregistry web
```


