### PR TITLE
Add `bioregistry.parse_iri()` functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,30 @@ assert 'eccode' == bioregistry.normalize_prefix('EC_CODE')
 assert bioregistry.normalize_prefix('not a real key') is None
 ```
 
+The Bioregistry can be used to parse CURIEs from IRIs due to its vast registry of provider URL
+strings and additional programmatic logic implemented with Python. It can parse OBO Library PURLs,
+IRIs from the OLS and identifiers.org, IRIs from the Bioregistry website, and any other IRIs
+from well-formed providers registered in the Bioregistry.
+
+```python
+import bioregistry
+
+# First-party IRI
+assert ('chebi', '24867') == bioregistry.parse_iri('https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:24867')
+
+# OLS IRI
+assert ('chebi', '24867') == bioregistry.parse_iri('https://www.ebi.ac.uk/ols/ontologies/chebi/terms?iri=http://purl.obolibrary.org/obo/CHEBI_24867')
+
+# Identifiers.org IRIs (with varying usage of HTTP(s) and colon/slash separator
+assert ('chebi', '24867') == bioregistry.parse_iri('https://identifiers.org/CHEBI:24867')
+assert ('chebi', '24867') == bioregistry.parse_iri('http://identifiers.org/CHEBI:24867')
+assert ('chebi', '24867') == bioregistry.parse_iri('https://identifiers.org/CHEBI/24867')
+assert ('chebi', '24867') == bioregistry.parse_iri('http://identifiers.org/CHEBI/24867')
+
+# Bioregistry IRI
+assert ('chebi', '24867') == bioregistry.parse_iri('https://bioregistry.io/chebi:24867')
+```
+
 The pattern for an entry in the Bioregistry can be looked up quickly with `get_pattern()` if
 it exists. It prefers the custom curated, then MIRIAM, then Wikidata pattern.
 
@@ -126,7 +150,7 @@ assert bioregistry.is_deprecated('nmr')
 assert not bioregistry.is_deprecated('efo')
 ```
 
-Entries in the Bioregistry can be looked up with the `get()` function.
+Entries in the Bioregistry can be looked up with the `get_resource()` function.
 
 ```python
 import bioregistry

--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ import bioregistry
 # First-party IRI
 assert ('chebi', '24867') == bioregistry.parse_iri('https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:24867')
 
+# OBO Library PURL
+assert ('chebi', '24867') == bioregistry.parse_iri('http://purl.obolibrary.org/obo/CHEBI_24867')
+
 # OLS IRI
 assert ('chebi', '24867') == bioregistry.parse_iri('https://www.ebi.ac.uk/ols/ontologies/chebi/terms?iri=http://purl.obolibrary.org/obo/CHEBI_24867')
 

--- a/src/bioregistry/__init__.py
+++ b/src/bioregistry/__init__.py
@@ -2,6 +2,7 @@
 
 """Extract registry information."""
 
+from .parse_iri import parse_iri  # noqa:F401
 from .resolve import (  # noqa:F401
     get_banana,
     get_bioportal_prefix,

--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -20446,7 +20446,7 @@
       "bioportal": "LOINC"
     },
     "name": "Logical Observation Identifiers Names and Codes",
-    "url": "https://loinc.org/$1/"
+    "url": "https://loinc.org/$1"
   },
   "lrg": {
     "mappings": {

--- a/src/bioregistry/parse_iri.py
+++ b/src/bioregistry/parse_iri.py
@@ -61,7 +61,7 @@ def parse_iri(iri: str) -> Union[Tuple[str, str], Tuple[None, None]]:
     .. todo:: IRI with weird embedding, like ones that end in .html
     """
     if iri.startswith(BIOREGISTRY_PREFIX):
-        curie = iri[len(BIOREGISTRY_PREFIX): ]
+        curie = iri[len(BIOREGISTRY_PREFIX) :]
         return parse_curie(curie)
     if iri.startswith(OLS_URL_PREFIX):
         sub_iri = iri.rsplit("=", 1)[1]
@@ -70,13 +70,21 @@ def parse_iri(iri: str) -> Union[Tuple[str, str], Tuple[None, None]]:
         return parse_obolibrary_purl(iri)
     if iri.startswith(IDOT_HTTPS_PREFIX):
         curie = iri[len(IDOT_HTTPS_PREFIX) :]
-        return parse_curie(curie)
+        return _safe_parse_curie(curie)
     if iri.startswith(IDOT_HTTP_PREFIX):
         curie = iri[len(IDOT_HTTP_PREFIX) :]
-        return parse_curie(curie)
+        return _safe_parse_curie(curie)
     for prefix, prefix_url in _D:
         if iri.startswith(prefix_url):
             return prefix, iri[len(prefix_url) :]
+    return None, None
+
+
+def _safe_parse_curie(curie: str) -> Union[Tuple[str, str], Tuple[None, None]]:
+    for sep in "_/:":
+        prefix, identifier = parse_curie(curie, sep)
+        if prefix is not None:
+            return prefix, identifier
     return None, None
 
 
@@ -93,7 +101,7 @@ def parse_obolibrary_purl(iri: str) -> Tuple[str, str]:
     ('fbbt', '0000001')
     """
     curie = iri[len("http://purl.obolibrary.org/obo/") :]
-    return parse_curie(curie, sep="_")
+    return _safe_parse_curie(curie)
 
 
 def _main():

--- a/src/bioregistry/parse_iri.py
+++ b/src/bioregistry/parse_iri.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+
+"""Functionality for parsing IRIs."""
+
 from typing import Tuple, Union
 
 from bioregistry.resolve import get_format_urls
@@ -15,8 +19,29 @@ def parse_iri(iri: str) -> Union[Tuple[str, str], Tuple[None, None]]:
     :param iri: A valid IRI
     :return: A pair of prefix/identifier, if can be parsed
 
+    IRIs from Identifiers.org (https and http):
+
+    >>> parse_iri("https://identifiers.org/aop.relationships:5")
+    ('aop.relationships', '5')
+    >>> parse_iri("http://identifiers.org/aop.relationships:5")
+    ('aop.relationships', '5')
+
+    IRI from an OBO PURL:
+
+    >>> parse_iri("http://purl.obolibrary.org/obo/DRON_00023232")
+    ('dron', '00023232')
+
+    IRI from the OLS:
+
+    >>> parse_iri("https://www.ebi.ac.uk/ols/ontologies/ecao/terms?iri=http://purl.obolibrary.org/obo/ECAO_0107180")
+    ('ecao', '0107180')
+
+    IRI from native provider
+
     >>> parse_iri("https://www.alzforum.org/mutations/1234")
     ('alzforum.mutation', '1234')
+
+    .. todo:: IRI with weird embedding, like ones that end in .html
     """
     for prefix, prefix_url in _D:
         if iri.startswith(prefix_url):
@@ -24,10 +49,10 @@ def parse_iri(iri: str) -> Union[Tuple[str, str], Tuple[None, None]]:
     return None, None
 
 
-def main():
+def _main():
     import bioregistry
     from tabulate import tabulate
-    rows=[]
+    rows = []
     for prefix, resource in bioregistry.read_registry().items():
         example = bioregistry.get_example(prefix)
         if example is None:
@@ -42,4 +67,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    _main()

--- a/src/bioregistry/parse_iri.py
+++ b/src/bioregistry/parse_iri.py
@@ -91,12 +91,12 @@ def parse_iri(iri: str) -> Union[Tuple[str, str], Tuple[None, None]]:
 def _safe_parse_curie(curie: str) -> Union[Tuple[str, str], Tuple[None, None]]:
     for sep in "_/:":
         prefix, identifier = parse_curie(curie, sep)
-        if prefix is not None:
+        if prefix is not None and identifier is not None:
             return prefix, identifier
     return None, None
 
 
-def parse_obolibrary_purl(iri: str) -> Tuple[str, str]:
+def parse_obolibrary_purl(iri: str) -> Union[Tuple[str, str], Tuple[None, None]]:
     """Parse an OBO Library PURL.
 
     :param iri: A valid IRI

--- a/src/bioregistry/parse_iri.py
+++ b/src/bioregistry/parse_iri.py
@@ -1,0 +1,45 @@
+from typing import Tuple, Union
+
+from bioregistry.resolve import get_format_urls
+
+__all__ = [
+    'parse_iri',
+]
+
+_D = sorted(get_format_urls().items(), key=lambda kv: -len(kv[0]))
+
+
+def parse_iri(iri: str) -> Union[Tuple[str, str], Tuple[None, None]]:
+    """Parse a compact identifier from an IRI.
+
+    :param iri: A valid IRI
+    :return: A pair of prefix/identifier, if can be parsed
+
+    >>> parse_iri("https://www.alzforum.org/mutations/1234")
+    ('alzforum.mutation', '1234')
+    """
+    for prefix, prefix_url in _D:
+        if iri.startswith(prefix_url):
+            return prefix, iri[len(prefix_url):]
+    return None, None
+
+
+def main():
+    import bioregistry
+    from tabulate import tabulate
+    rows=[]
+    for prefix, resource in bioregistry.read_registry().items():
+        example = bioregistry.get_example(prefix)
+        if example is None:
+            continue
+        iri = bioregistry.get_link(prefix, example, use_bioregistry_io=False)
+        if iri is None:
+            # print('no iri for', prefix, example)
+            continue
+        k, v = parse_iri(iri)
+        rows.append((prefix, example, iri, k, v))
+    print(tabulate(rows))
+
+
+if __name__ == '__main__':
+    main()

--- a/src/bioregistry/parse_iri.py
+++ b/src/bioregistry/parse_iri.py
@@ -17,6 +17,7 @@ BIOREGISTRY_PREFIX = "https://bioregistry.io"
 OBO_PREFIX = "http://purl.obolibrary.org/obo/"
 IDOT_HTTPS_PREFIX = "https://identifiers.org/"
 IDOT_HTTP_PREFIX = "http://identifiers.org/"
+N2T_PREFIX = "https://n2t.net/"
 
 
 def parse_iri(iri: str) -> Union[Tuple[str, str], Tuple[None, None]]:
@@ -58,6 +59,10 @@ def parse_iri(iri: str) -> Union[Tuple[str, str], Tuple[None, None]]:
     >>> parse_iri("http://identifiers.org/aop.relationships/5")
     ('aop.relationships', '5')
 
+    IRI from N2T
+    >>> parse_iri("https://n2t.net/aop.relationships:5")
+    ('aop.relationships', '5')
+
     .. todo:: IRI with weird embedding, like ones that end in .html
     """
     if iri.startswith(BIOREGISTRY_PREFIX):
@@ -74,6 +79,9 @@ def parse_iri(iri: str) -> Union[Tuple[str, str], Tuple[None, None]]:
     if iri.startswith(IDOT_HTTP_PREFIX):
         curie = iri[len(IDOT_HTTP_PREFIX) :]
         return _safe_parse_curie(curie)
+    if iri.startswith(N2T_PREFIX):
+        curie = iri[len(N2T_PREFIX) :]
+        return parse_curie(curie)
     for prefix, prefix_url in _D:
         if iri.startswith(prefix_url):
             return prefix, iri[len(prefix_url) :]

--- a/src/bioregistry/parse_iri.py
+++ b/src/bioregistry/parse_iri.py
@@ -4,13 +4,15 @@
 
 from typing import Tuple, Union
 
-from bioregistry.resolve import get_format_urls, parse_curie
+from .resolve import get_format_urls, parse_curie
 
 __all__ = [
     "parse_iri",
 ]
 
-_D = sorted(get_format_urls().items(), key=lambda kv: -len(kv[0]))
+#: A prefix map in reverse sorted order based on length of the URL
+#: in order to avoid conflicts of sub-URIs (thanks to Nico Matentzoglu for the idea)
+PREFIX_MAP = sorted(get_format_urls().items(), key=lambda kv: -len(kv[0]))
 
 OLS_URL_PREFIX = "https://www.ebi.ac.uk/ols/ontologies/"
 BIOREGISTRY_PREFIX = "https://bioregistry.io"
@@ -82,7 +84,7 @@ def parse_iri(iri: str) -> Union[Tuple[str, str], Tuple[None, None]]:
     if iri.startswith(N2T_PREFIX):
         curie = iri[len(N2T_PREFIX) :]
         return parse_curie(curie)
-    for prefix, prefix_url in _D:
+    for prefix, prefix_url in PREFIX_MAP:
         if iri.startswith(prefix_url):
             return prefix, iri[len(prefix_url) :]
     return None, None
@@ -113,6 +115,7 @@ def parse_obolibrary_purl(iri: str) -> Union[Tuple[str, str], Tuple[None, None]]
 
 
 def _main():
+    """Run this as ``python -m bioregistry.parse_iri`` to get a list of IRIs that can be constructed, but not parsed."""
     import bioregistry
     from tabulate import tabulate
 

--- a/src/bioregistry/parse_iri.py
+++ b/src/bioregistry/parse_iri.py
@@ -109,7 +109,7 @@ def parse_obolibrary_purl(iri: str) -> Tuple[str, str]:
     ('fbbt', '0000001')
     """
     curie = iri[len("http://purl.obolibrary.org/obo/") :]
-    return _safe_parse_curie(curie)
+    return parse_curie(curie, sep="_")
 
 
 def _main():
@@ -119,7 +119,7 @@ def _main():
     rows = []
     for prefix in bioregistry.read_registry():
         example = bioregistry.get_example(prefix)
-        if example is None or len(example) > 30:
+        if example is None:
             continue
         iri = bioregistry.get_link(prefix, example, use_bioregistry_io=False)
         if iri is None:

--- a/src/bioregistry/parse_iri.py
+++ b/src/bioregistry/parse_iri.py
@@ -89,7 +89,7 @@ def _safe_parse_curie(curie: str) -> Union[Tuple[str, str], Tuple[None, None]]:
 
 
 def parse_obolibrary_purl(iri: str) -> Tuple[str, str]:
-    """Parse an OBO Library PURL
+    """Parse an OBO Library PURL.
 
     :param iri: A valid IRI
     :return: A pair of prefix/identifier, if can be parsed
@@ -109,7 +109,7 @@ def _main():
     from tabulate import tabulate
 
     rows = []
-    for prefix, resource in bioregistry.read_registry().items():
+    for prefix in bioregistry.read_registry():
         example = bioregistry.get_example(prefix)
         if example is None or len(example) > 30:
             continue

--- a/src/bioregistry/resolve.py
+++ b/src/bioregistry/resolve.py
@@ -572,17 +572,17 @@ def get_format_url(prefix: str, priority: Optional[Sequence[str]] = None) -> Opt
     """
     fmt = get_format(prefix, priority=priority)
     if fmt is None:
-        logging.warning("term missing formatter: %s", prefix)
+        logging.debug("term missing formatter: %s", prefix)
         return None
     count = fmt.count("$1")
     if 0 == count:
-        logging.warning("formatter missing $1: %s", prefix)
+        logging.debug("formatter missing $1: %s", prefix)
         return None
     if fmt.count("$1") != 1:
-        logging.warning("formatter has multiple $1: %s", prefix)
+        logging.debug("formatter has multiple $1: %s", prefix)
         return None
     if not fmt.endswith("$1"):
-        logging.warning("formatter does not end with $1: %s", prefix)
+        logging.debug("formatter does not end with $1: %s", prefix)
         return None
     return fmt[: -len("$1")]
 

--- a/src/bioregistry/resolve.py
+++ b/src/bioregistry/resolve.py
@@ -767,11 +767,17 @@ def is_proprietary(prefix: str) -> Optional[bool]:
     return entry.proprietary
 
 
-def parse_curie(curie: str) -> Union[Tuple[str, str], Tuple[None, None]]:
+def parse_curie(curie: str, sep: str = ":") -> Union[Tuple[str, str], Tuple[None, None]]:
     """Parse a CURIE, normalizing the prefix and identifier if necessary.
 
     :param curie: A compact URI (CURIE) in the form of <prefix:identifier>
+    :param sep: The separator for the CURIE. Defaults to the semicolon ":" however the slash
+        "/" is sometimes used in Identifiers.org and the underscore "_" is used for OBO PURLs.
     :returns: A tuple of the prefix, identifier. If not parsable, returns a tuple of None, None
+
+    The algorithm for parsing a CURIE is very simple: it splits the string on the leftmost occurrence
+    of the separator (usually a colon ":" unless specified otherwise). The left part is the prefix,
+    and the right part is the identifier.
 
     >>> parse_curie('pdb:1234')
     ('pdb', '1234')
@@ -797,9 +803,13 @@ def parse_curie(curie: str) -> Union[Tuple[str, str], Tuple[None, None]]:
     ('go.ref', '1234')
     >>> parse_curie('go.ref:1234')
     ('go.ref', '1234')
+
+    Parse OBO PURL curies
+    >>> parse_curie('GO_1234', sep="_")
+    ('go', '1234')
     """
     try:
-        prefix, identifier = curie.split(":", 1)
+        prefix, identifier = curie.split(sep, 1)
     except ValueError:
         return None, None
     return normalize_curie(prefix, identifier)


### PR DESCRIPTION
While being able to turn IRIs into CURIEs wasn't part of the original goals of the bioregistry, it has most of the metadata that would be necessary to implement such a function.