### PR TITLE
Override EC code URL

### DIFF
--- a/src/bioregistry/data/bioregistry.json
+++ b/src/bioregistry/data/bioregistry.json
@@ -9891,6 +9891,7 @@
       "ec-code",
       "intenz"
     ],
+    "url": "https://www.ebi.ac.uk/intenz/query?cmd=SearchEC&ec=$1",
     "wikidata": {
       "prefix": "P591"
     }


### PR DESCRIPTION
The ID pattern specified by identifiers.org for `eccode` for higher-level enzyme classes (for instance 1.1.-.-) cannot be resolved (i.e., https://identifiers.org/ec-code:1.1.-.- doesn't work). Bioregistry overrides the ID pattern for `eccode` to `^\d{1,2}(\.\d{0,3}){0,3}$` to allow EC codes like 1.1 but doesn't override the URL resolution, so identifiers.org still blocks resolving e.g., https://identifiers.org/ec-code:1 due to an invalid ID format. This PR updates the resolution URL to fix this.