### PR TITLE
Add health check scripts

### DIFF
--- a/.github/workflows/health.yml
+++ b/.github/workflows/health.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           python-version: 3.9
       - name: Install the Bioregistry
-        run: pip install .
+        run: pip install .[health]
       - name: Run the homepage checks
         run: python -m bioregistry.health homepages
   providers:
@@ -27,6 +27,6 @@ jobs:
         with:
           python-version: 3.9
       - name: Install the Bioregistry
-        run: pip install .
+        run: pip install .[health]
       - name: Run the provider checks
         run: python -m bioregistry.health providers

--- a/.github/workflows/health.yml
+++ b/.github/workflows/health.yml
@@ -1,0 +1,32 @@
+name: Health
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0"
+jobs:
+  homepage:
+    name: Homepage Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install the Bioregistry
+        run: pip install .
+      - name: Install the Bioregistry
+        run: python -m bioregistry.health homepages
+  providers:
+    name: Provider Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install the Bioregistry
+        run: pip install .
+      - name: Install the Bioregistry
+        run: python -m bioregistry.health providers

--- a/.github/workflows/health.yml
+++ b/.github/workflows/health.yml
@@ -15,7 +15,7 @@ jobs:
           python-version: 3.9
       - name: Install the Bioregistry
         run: pip install .
-      - name: Install the Bioregistry
+      - name: Run the homepage checks
         run: python -m bioregistry.health homepages
   providers:
     name: Provider Check
@@ -28,5 +28,5 @@ jobs:
           python-version: 3.9
       - name: Install the Bioregistry
         run: pip install .
-      - name: Install the Bioregistry
+      - name: Run the provider checks
         run: python -m bioregistry.health providers

--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ Things that would be helpful:
 A full list of curation to-do's is automatically generated as a web page
 [here](https://bioregistry.github.io/bioregistry/curation/). This page also has a more in-depth tutorial on how to contribute.
 
+
+### 🫀 Health Report
+
+[![Health Report](https://github.com/bioregistry/bioregistry/actions/workflows/health.yml/badge.svg)](https://github.com/bioregistry/bioregistry/actions/workflows/health.yml)
+
+The Bioregistry runs some automated tests weekly to check that various metadata haven't gone stale. For example,
+it checks that the homepages are still available and that each provider URL is still able to resolve.
+
 ## 🚀 Installation
 
 The Bioregistry can be installed from [PyPI](https://pypi.org/project/bioregistry/) with:

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,6 @@ install_requires =
     pystow>=0.1.0
     pyyaml
     click
-    click_default_group
     more_click
     more_itertools
     tabulate
@@ -82,6 +81,9 @@ charts =
     matplotlib
     matplotlib_venn
     seaborn
+health =
+    click_default_group
+    pandas
 web =
     flask
     flasgger

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ install_requires =
     pystow>=0.1.0
     pyyaml
     click
+    click_default_group
     more_click
     more_itertools
     tabulate

--- a/src/bioregistry/health/__init__.py
+++ b/src/bioregistry/health/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+"""An assortment of tests that can be run to check the health of the bioregistry."""

--- a/src/bioregistry/health/__main__.py
+++ b/src/bioregistry/health/__main__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+
+"""A central CLI for Bioregistry health checks."""
+
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/src/bioregistry/health/check_homepages.py
+++ b/src/bioregistry/health/check_homepages.py
@@ -2,6 +2,7 @@
 
 """A script to check which homepages in entries in the Bioregistry actually can be accessed."""
 
+import sys
 from collections import defaultdict
 from datetime import datetime
 from typing import Optional, Set, Tuple
@@ -79,6 +80,7 @@ def main():
         ],
     )
     click.echo(df.to_markdown())
+    sys.exit(1 if 0 < failed else 0)
 
 
 if __name__ == "__main__":

--- a/src/bioregistry/health/check_homepages.py
+++ b/src/bioregistry/health/check_homepages.py
@@ -3,14 +3,14 @@
 """A script to check which homepages in entries in the Bioregistry actually can be accessed."""
 
 from collections import defaultdict
+from datetime import datetime
+from typing import Optional, Set, Tuple
 
 import click
 import pandas as pd
 import requests
-from datetime import datetime
 from tqdm import tqdm
 from tqdm.contrib.concurrent import thread_map
-from typing import Optional, Set, Tuple
 
 import bioregistry
 

--- a/src/bioregistry/health/check_homepages.py
+++ b/src/bioregistry/health/check_homepages.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+
+"""A script to check which homepages in entries in the Bioregistry actually can be accessed."""
+
+from collections import defaultdict
+
+import click
+import pandas as pd
+import requests
+from datetime import datetime
+from tqdm import tqdm
+from tqdm.contrib.concurrent import thread_map
+from typing import Optional, Set, Tuple
+
+import bioregistry
+
+__all__ = [
+    "main",
+]
+
+
+def _process(element: Tuple[str, Set[str]]) -> Tuple[str, Set[str], bool, Optional[str]]:
+    homepage, prefixes = element
+    if "github.com" in homepage:  # skip github links for now
+        return homepage, prefixes, False, None
+    if "purl.obolibrary.org" in homepage:  # this is never acceptable
+        return homepage, prefixes, True, "no PURLs allowed"
+
+    failed = False
+    msg = None
+    try:
+        res = requests.get(homepage, timeout=10)
+    except IOError as e:
+        failed = True
+        msg = e.__class__.__name__
+    else:
+        if res.status_code != 200:
+            failed = True
+            msg = f"status: {res.status_code}"
+    if failed:
+        with tqdm.external_write_mode():
+            click.echo(
+                f'[{datetime.now().strftime("%H:%M:%S")}] '
+                + click.style(", ".join(sorted(prefixes)), fg="green")
+                + " at "
+                + click.style(homepage, fg="red")
+                + " failed to download: "
+                + click.style(msg, fg="bright_black")
+            )
+    return homepage, prefixes, failed, msg
+
+
+@click.command()
+def main():
+    """Run the homepage health check script."""
+    homepage_to_prefixes = defaultdict(set)
+    for prefix in bioregistry.read_registry():
+        if bioregistry.is_deprecated(prefix):
+            continue
+        homepage = bioregistry.get_homepage(prefix)
+        if homepage is None:
+            continue
+        homepage_to_prefixes[homepage].add(prefix)
+
+    rv = thread_map(_process, list(homepage_to_prefixes.items()), desc="Checking homepages")
+
+    failed = sum(failed for _, _, failed, _ in rv)
+    click.secho(
+        f"{failed}/{len(rv)} ({failed / len(rv):.2%}) homepages failed to load", fg="red", bold=True
+    )
+
+    df = pd.DataFrame(
+        columns=["prefix", "homepage", "message"],
+        data=[
+            (prefix, homepage, msg)
+            for homepage, prefixes, failed, msg in rv
+            if failed
+            for prefix in prefixes
+        ],
+    )
+    click.echo(df.to_markdown())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bioregistry/health/check_homepages.py
+++ b/src/bioregistry/health/check_homepages.py
@@ -27,7 +27,7 @@ def _process(element: Tuple[str, Set[str]]) -> Tuple[str, Set[str], bool, Option
         return homepage, prefixes, True, "no PURLs allowed"
 
     failed = False
-    msg = ''
+    msg = ""
     try:
         res = requests.get(homepage, timeout=10)
     except IOError as e:

--- a/src/bioregistry/health/check_homepages.py
+++ b/src/bioregistry/health/check_homepages.py
@@ -27,7 +27,7 @@ def _process(element: Tuple[str, Set[str]]) -> Tuple[str, Set[str], bool, Option
         return homepage, prefixes, True, "no PURLs allowed"
 
     failed = False
-    msg = None
+    msg = ''
     try:
         res = requests.get(homepage, timeout=10)
     except IOError as e:

--- a/src/bioregistry/health/check_providers.py
+++ b/src/bioregistry/health/check_providers.py
@@ -3,7 +3,7 @@
 """A script to check which providers in entries in the Bioregistry actually can be accessed."""
 
 from datetime import datetime
-from typing import Optional, Tuple
+from typing import Tuple
 
 import click
 import pandas as pd
@@ -23,7 +23,7 @@ def _process(element: Tuple[str, str, str]) -> Tuple[str, str, str, bool, str]:
     prefix, example, url = element
 
     failed = False
-    msg = ''
+    msg = ""
     try:
         res = requests.get(url, timeout=10)
     except IOError as e:

--- a/src/bioregistry/health/check_providers.py
+++ b/src/bioregistry/health/check_providers.py
@@ -2,13 +2,14 @@
 
 """A script to check which providers in entries in the Bioregistry actually can be accessed."""
 
+from datetime import datetime
+from typing import Optional, Tuple
+
 import click
 import pandas as pd
 import requests
-from datetime import datetime
 from tqdm import tqdm
 from tqdm.contrib.concurrent import thread_map
-from typing import Optional, Tuple
 
 import bioregistry
 from bioregistry.utils import secho

--- a/src/bioregistry/health/check_providers.py
+++ b/src/bioregistry/health/check_providers.py
@@ -2,6 +2,7 @@
 
 """A script to check which providers in entries in the Bioregistry actually can be accessed."""
 
+import sys
 from datetime import datetime
 from typing import Tuple
 
@@ -76,6 +77,7 @@ def main():
         data=[(prefix, example, url, msg) for prefix, example, url, failed, msg in rv if failed],
     )
     click.echo(df.to_markdown())
+    sys.exit(1 if 0 < failed else 0)
 
 
 if __name__ == "__main__":

--- a/src/bioregistry/health/check_providers.py
+++ b/src/bioregistry/health/check_providers.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+
+"""A script to check which providers in entries in the Bioregistry actually can be accessed."""
+
+import click
+import pandas as pd
+import requests
+from datetime import datetime
+from tqdm import tqdm
+from tqdm.contrib.concurrent import thread_map
+from typing import Optional, Tuple
+
+import bioregistry
+from bioregistry.utils import secho
+
+__all__ = [
+    "main",
+]
+
+
+def _process(element: Tuple[str, str, str]) -> Tuple[str, str, str, bool, Optional[str]]:
+    prefix, example, url = element
+
+    failed = False
+    msg = None
+    try:
+        res = requests.get(url, timeout=10)
+    except IOError as e:
+        failed = True
+        msg = e.__class__.__name__
+    else:
+        if res.status_code != 200:
+            failed = True
+            msg = f"status: {res.status_code}"
+    if failed:
+        with tqdm.external_write_mode():
+            click.echo(
+                f'[{datetime.now().strftime("%H:%M:%S")}] '
+                + click.style(prefix, fg="green")
+                + " at "
+                + click.style(url, fg="red")
+                + " failed to download: "
+                + click.style(msg, fg="bright_black")
+            )
+    return prefix, example, url, failed, msg
+
+
+@click.command()
+def main():
+    """Run the provider health check script."""
+    rows = []
+    for prefix in bioregistry.read_registry():
+        if bioregistry.is_deprecated(prefix):
+            continue
+        example = bioregistry.get_example(prefix)
+        if example is None:
+            continue
+
+        url = bioregistry.get_link(prefix, example, use_bioregistry_io=False)
+        if url is None:
+            secho(f"[{prefix}] failed to generate URL for example {example}", fg="red")
+            continue
+
+        rows.append((prefix, example, url))
+
+    rv = thread_map(_process, rows, desc="Checking providers")
+
+    failed = sum(failed for _, _, _, failed, _ in rv)
+    click.secho(
+        f"{failed}/{len(rv)} ({failed / len(rv):.2%}) providers failed", fg="red", bold=True
+    )
+
+    df = pd.DataFrame(
+        columns=["prefix", "example", "url", "message"],
+        data=[(prefix, example, url, msg) for prefix, example, url, failed, msg in rv if failed],
+    )
+    click.echo(df.to_markdown())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bioregistry/health/check_providers.py
+++ b/src/bioregistry/health/check_providers.py
@@ -19,11 +19,11 @@ __all__ = [
 ]
 
 
-def _process(element: Tuple[str, str, str]) -> Tuple[str, str, str, bool, Optional[str]]:
+def _process(element: Tuple[str, str, str]) -> Tuple[str, str, str, bool, str]:
     prefix, example, url = element
 
     failed = False
-    msg = None
+    msg = ''
     try:
         res = requests.get(url, timeout=10)
     except IOError as e:

--- a/src/bioregistry/health/cli.py
+++ b/src/bioregistry/health/cli.py
@@ -21,18 +21,19 @@ COMMANDS = {
     name="health",
     commands=COMMANDS.copy(),
     cls=DefaultGroup,
-    default='all', default_if_no_args=True,
+    default="all",
+    default_if_no_args=True,
 )
 def main():
     """Run the bioregistry health tests."""
 
 
-@main.command(name='all')
+@main.command(name="all")
 @click.pass_context
 def run_all_commands(ctx: click.Context):
     """Run all."""
     for name, command in COMMANDS.items():
-        click.secho(f'Running python -m bioregistry.health {name}', fg='green')
+        click.secho(f"Running python -m bioregistry.health {name}", fg="green")
         ctx.invoke(command)
 
 

--- a/src/bioregistry/health/cli.py
+++ b/src/bioregistry/health/cli.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+"""A central CLI for Bioregistry health checks."""
+
+import click
+
+from . import check_homepages, check_providers
+
+__all__ = [
+    "main",
+]
+
+# TODO add default command that runs them all
+
+main = click.Group(
+    name="health",
+    commands={
+        "homepages": check_homepages.main,
+        "providers": check_providers.main,
+    },
+)
+
+if __name__ == "__main__":
+    main()

--- a/src/bioregistry/health/cli.py
+++ b/src/bioregistry/health/cli.py
@@ -3,6 +3,7 @@
 """A central CLI for Bioregistry health checks."""
 
 import click
+from click_default_group import DefaultGroup
 
 from . import check_homepages, check_providers
 
@@ -10,15 +11,30 @@ __all__ = [
     "main",
 ]
 
-# TODO add default command that runs them all
+COMMANDS = {
+    "homepages": check_homepages.main,
+    "providers": check_providers.main,
+}
 
-main = click.Group(
+
+@click.group(
     name="health",
-    commands={
-        "homepages": check_homepages.main,
-        "providers": check_providers.main,
-    },
+    commands=COMMANDS.copy(),
+    cls=DefaultGroup,
+    default='all', default_if_no_args=True,
 )
+def main():
+    """Run the bioregistry health tests."""
+
+
+@main.command(name='all')
+@click.pass_context
+def run_all_commands(ctx: click.Context):
+    """Run all."""
+    for name, command in COMMANDS.items():
+        click.secho(f'Running python -m bioregistry.health {name}', fg='green')
+        ctx.invoke(command)
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_identifiers_org.py
+++ b/tests/test_identifiers_org.py
@@ -54,30 +54,25 @@ class TestIdentifiersOrg(unittest.TestCase):
                 res = self.session.get(url, allow_redirects=False)
                 self.assertEqual(302, res.status_code, msg=f"failed with URL: {url}")
 
+    @unittest.skip
     def test_url_auto(self):
         """Test formatting URLs."""
-        for prefix, entry in bioregistry.read_registry().items():
-            if prefix in IDOT_BROKEN:
-                continue
-            identifier = bioregistry.get_example(prefix)
-            if identifier is None:
-                continue
-            if "example" not in entry and "banana" not in entry and "pattern" not in entry:
+        for prefix in bioregistry.read_registry():
+            miriam_prefix = bioregistry.get_identifiers_org_prefix(prefix)
+            if miriam_prefix is None or prefix in IDOT_BROKEN:
                 continue
 
-            url = get_identifiers_org_url(prefix, identifier)
-            if url is None:
-                continue
+            identifier = bioregistry.get_example(prefix)
 
             with self.subTest(prefix=prefix, identifier=identifier):
-                # FIXME
-                # The following tests don't work because the CURIE generation often throws away the prefix.
-                # miriam_prefix = bioregistry.get_identifiers_org_prefix(prefix)
-                # self.assertIsNotNone(miriam_prefix)
-                # self.assertTrue(
-                #     url.startswith(f'https://identifiers.org/{miriam_prefix}:'),
-                #     msg=f"bad prefix for {prefix}. Expected {miriam_prefix} in {url}",
-                # )
+                self.assertIsNotNone(identifier, msg="All MIRIAM entries should have an example")
+
+                url = get_identifiers_org_url(prefix, identifier)
+                self.assertIsNotNone(url, msg="All MIRIAM entries should be formattable")
+                self.assertTrue(
+                    url.startswith(f"https://identifiers.org/{miriam_prefix}:"),
+                    msg=f"bad prefix for {prefix}. Expected {miriam_prefix} in {url}",
+                )
                 res = self.session.get(url, allow_redirects=False)
                 self.assertEqual(
                     302,


### PR DESCRIPTION
This PR adds a new directory of scripts that can be run periodically to check the health of the bioregistry (and perhaps other registries, since there are plenty of identifiers.org health scripts I've written)